### PR TITLE
Loan FC v1.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,34 @@
 ## Backend 
 (Always make the recent update ascending after this)
 
+Update #55
+- Implemented GET /api/groups endpoint to return all groups (id, group_name) for inter-group loan selection by Finance Coordinators.
+- Fixed /api/loans/approved endpoint to ensure it returns only approved loans for the FC's group and does not expect a string parameter. This resolves the 500 error when fetching approved loans.
+
+Update #54
+- Implemented API endpoint for Finance Coordinators to request inter-group loans:
+  - Added POST /api/loans/request/inter
+  - Accepts target_group_id, amount, due_date, and notes
+  - Validates permissions and prevents duplicate active requests
+  - Only the FC of a group can perform this action
+- Added Cloudinary filename pattern for loan repayment proof uploads:
+  - Filenames now use loanrepayments/repayment_LOANID_USERID_MMDDYYYY_HHMMSS for loan repayment proofs
+
+Update #53
+
+- Implemented API endpoint for Finance Coordinators to record manual/cash loan repayments:
+  - Added POST /api/loans/:loanId/record-repayment
+  - Accepts amount (required), optional repayment date, notes, and proof upload
+  - Creates a loan_repayments record, updates loans.total_amount_repaid, and updates loan status if fully repaid
+  - Only the FC of the providing group can perform this action
+
+Update #52
+- Implemented API endpoint for Finance Coordinators to mark a loan as disbursed:
+  - Added POST /api/loans/:loanId/disburse
+  - Accepts optional proof upload, reference ID, and notes
+  - Updates loan status to 'disbursed', sets disbursement date, stores proof/ref ID, and disbursed_by_user_id
+  - Only the FC of the providing group can perform this action
+
 Update #51
 - Implemented comprehensive Loan Management for Finance Coordinators:
   - Added API endpoints for retrieving pending intra-group and inter-group loans

--- a/backend/src/controllers/groupController.js
+++ b/backend/src/controllers/groupController.js
@@ -1180,6 +1180,17 @@ const getPendingInterGroupLoansIncoming = async (req, res) => {
   }
 };
 
+// Get all thesis groups (id, group_name) for FC inter-group loan selection
+const getAllGroups = async (req, res) => {
+  try {
+    const result = await db.query("SELECT id, group_name FROM groups WHERE group_type = 'thesis' ORDER BY group_name ASC");
+    res.json(result.rows);
+  } catch (error) {
+    console.error('Get all groups error:', error);
+    res.status(500).json({ error: 'Server error while fetching groups' });
+  }
+};
+
 module.exports = {
   createGroup,
   getGroup,
@@ -1195,5 +1206,6 @@ module.exports = {
   updateExpense,
   deleteExpense,
   getPendingIntraGroupLoans,
-  getPendingInterGroupLoansIncoming
+  getPendingInterGroupLoansIncoming,
+  getAllGroups
 }; 

--- a/backend/src/routes/groupRoutes.js
+++ b/backend/src/routes/groupRoutes.js
@@ -23,6 +23,9 @@ const upload = multer({
 // Protected routes - require authentication
 router.use(authenticateToken);
 
+// Add after router.use(authenticateToken)
+router.get('/', require('../controllers/groupController').getAllGroups);
+
 // Create a new group
 router.post('/', createGroup);
 

--- a/backend/src/routes/loanRoutes.js
+++ b/backend/src/routes/loanRoutes.js
@@ -7,17 +7,44 @@ const {
   getUserLoans,
   approveLoan,
   rejectLoan,
-  getApprovedLoans
+  getApprovedLoans,
+  markLoanAsDisbursed,
+  recordLoanRepayment,
+  requestInterGroupLoan
 } = require('../controllers/loanController');
+const multer = require('multer');
 
 // Student routes - requesting and viewing loans
 router.post('/request/intra', authenticateToken, requestIntraLoan);
+router.post('/request/inter', authenticateToken, isFinanceCoordinator, requestInterGroupLoan);
 router.get('/my-loans', authenticateToken, getUserLoans);
 router.get('/:loanId', authenticateToken, getLoanById);
 
 // Finance Coordinator routes for loan management
 router.post('/:loanId/approve', authenticateToken, isFinanceCoordinator, approveLoan);
 router.post('/:loanId/reject', authenticateToken, isFinanceCoordinator, rejectLoan);
+router.post('/:loanId/disburse', authenticateToken, isFinanceCoordinator, multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 5 * 1024 * 1024 },
+  fileFilter: (req, file, cb) => {
+    if (file.mimetype.startsWith('image/')) {
+      cb(null, true);
+    } else {
+      cb(new Error('Only image files are allowed'));
+    }
+  }
+}).single('disbursement_proof'), markLoanAsDisbursed);
+router.post('/:loanId/record-repayment', authenticateToken, isFinanceCoordinator, multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 5 * 1024 * 1024 },
+  fileFilter: (req, file, cb) => {
+    if (file.mimetype.startsWith('image/')) {
+      cb(null, true);
+    } else {
+      cb(new Error('Only image files are allowed'));
+    }
+  }
+}).single('repayment_proof'), recordLoanRepayment);
 router.get('/approved', authenticateToken, isFinanceCoordinator, getApprovedLoans);
 
 module.exports = router; 

--- a/backend/src/utils/cloudinary.js
+++ b/backend/src/utils/cloudinary.js
@@ -55,6 +55,12 @@ const generateExpenseReceiptFilename = (category, amount, quantity, unit, date =
   return `ER_${safeCategory}${safeAmount}-${safeQuantity}${safeUnit}_${formattedDate}`;
 };
 
+// Add this function for loan repayment proof filenames
+const generateLoanRepaymentFilename = (loanId, userId, date = new Date()) => {
+  const formattedDate = formatDateForFilename(date);
+  return `loanrepayments/repayment_${loanId}_${userId}_${formattedDate}`;
+};
+
 /**
  * Upload a file to Cloudinary
  * @param {Object} file - The file object from multer
@@ -67,7 +73,9 @@ const uploadToCloudinary = async (file, metadata = {}) => {
     const dataURI = `data:${file.mimetype};base64,${b64}`;
 
     let publicId;
-    if (metadata.expenseReceipt && metadata.category && metadata.amount && metadata.quantity && metadata.unit) {
+    if (metadata.loanRepayment && metadata.loanId && metadata.userId) {
+      publicId = generateLoanRepaymentFilename(metadata.loanId, metadata.userId);
+    } else if (metadata.expenseReceipt && metadata.category && metadata.amount && metadata.quantity && metadata.unit) {
       publicId = `expenses/${generateExpenseReceiptFilename(metadata.category, metadata.amount, metadata.quantity, metadata.unit)}`;
     } else if (metadata.profilePic && metadata.lastName) {
       publicId = `profile_pics/${formatProfilePicFilename(metadata.lastName)}`;
@@ -100,4 +108,5 @@ module.exports = {
   formatDateForFilename,
   formatProfilePicFilename,
   generateExpenseReceiptFilename,
+  generateLoanRepaymentFilename,
 }; 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "zg-llanes",
+  "name": "zengarden-thesis",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "zg-llanes",
+      "name": "zengarden-thesis",
       "version": "1.0.0",
       "dependencies": {
         "@headlessui/react": "^2.2.2",
@@ -14,6 +14,7 @@
         "@types/react-router-dom": "^5.3.3",
         "cropperjs": "^2.0.0",
         "date-fns": "^4.1.0",
+        "lucide-react": "^0.508.0",
         "prop-types": "^15.8.1",
         "react": "^19.0.0",
         "react-cropper": "^2.3.3",
@@ -3389,6 +3390,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.508.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.508.0.tgz",
+      "integrity": "sha512-gcP16PnexqtOFrTtv98kVsGzTfnbPekzZiQfByi2S89xfk7E/4uKE1USZqccIp58v42LqkO7MuwpCqshwSrJCg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/merge2": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
     "@types/react-router-dom": "^5.3.3",
     "cropperjs": "^2.0.0",
     "date-fns": "^4.1.0",
+    "lucide-react": "^0.508.0",
     "prop-types": "^15.8.1",
     "react": "^19.0.0",
     "react-cropper": "^2.3.3",

--- a/frontend/src/components/ui/Navigation.tsx
+++ b/frontend/src/components/ui/Navigation.tsx
@@ -27,7 +27,7 @@ const TypewriterEffect: React.FC = () => {
     "please work",
     "ctrl+s for life",
     "lorem ipsum",
-    "debugging marathon",
+    "creating bugs",
     "push to main",
     "merge conflicts",
     "help me grok",
@@ -47,7 +47,9 @@ const TypewriterEffect: React.FC = () => {
     "404 not found",
     "console.log life",
     "import caffeine",
-    "alt+tab master"
+    "alt+tab master",
+    "gl sa ojt <3",
+    "zengarden dev"
   ];
 
   const [currentText, setCurrentText] = useState("");


### PR DESCRIPTION
## Backend

Update #55
- Implemented GET /api/groups endpoint to return all groups (id, group_name) for inter-group loan selection by Finance Coordinators.
- Fixed /api/loans/approved endpoint to ensure it returns only approved loans for the FC's group and does not expect a string parameter. This resolves the 500 error when fetching approved loans.

Update #54
- Implemented API endpoint for Finance Coordinators to request inter-group loans:
  - Added POST /api/loans/request/inter
  - Accepts target_group_id, amount, due_date, and notes
  - Validates permissions and prevents duplicate active requests
  - Only the FC of a group can perform this action
- Added Cloudinary filename pattern for loan repayment proof uploads:
  - Filenames now use loanrepayments/repayment_LOANID_USERID_MMDDYYYY_HHMMSS for loan repayment proofs

Update #53

- Implemented API endpoint for Finance Coordinators to record manual/cash loan repayments:
  - Added POST /api/loans/:loanId/record-repayment
  - Accepts amount (required), optional repayment date, notes, and proof upload
  - Creates a loan_repayments record, updates loans.total_amount_repaid, and updates loan status if fully repaid
  - Only the FC of the providing group can perform this action

Update #52
- Implemented API endpoint for Finance Coordinators to mark a loan as disbursed:
  - Added POST /api/loans/:loanId/disburse
  - Accepts optional proof upload, reference ID, and notes
  - Updates loan status to 'disbursed', sets disbursement date, stores proof/ref ID, and disbursed_by_user_id
  - Only the FC of the providing group can perform this action